### PR TITLE
Update versions and Add same behavior into MainActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,25 +33,25 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.1.0-beta01'
-        kotlinCompilerVersion "1.5.31"
+        kotlinCompilerExtensionVersion '1.2.0-alpha01'
+        kotlinCompilerVersion "1.6.10"
     }
 }
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
-    implementation "androidx.glance:glance-appwidget:1.0.0-SNAPSHOT"
-    implementation "androidx.compose.ui:ui:1.0.5"
-    implementation "androidx.compose.material:material:1.0.5"
-    implementation "androidx.compose.ui:ui-tooling:1.0.5"
+    implementation "androidx.glance:glance-appwidget:1.0.0-alpha02"
+    implementation "androidx.compose.ui:ui:1.2.0-alpha02"
+    implementation "androidx.compose.material:material:1.2.0-alpha02"
+    implementation "androidx.compose.ui:ui-tooling:1.2.0-alpha02"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
     implementation 'androidx.activity:activity-compose:1.4.0'
 
-    testImplementation 'junit:junit:4.+'
+    testImplementation 'junit:junit:'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/src/main/java/meehan/matthew/waterwidget/MainActivity.kt
+++ b/app/src/main/java/meehan/matthew/waterwidget/MainActivity.kt
@@ -1,11 +1,18 @@
 package meehan.matthew.waterwidget
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContent{
+            val glassesOfWater by glassesOfWater().collectAsState(0)
+            WaterActivityContent(modifier = Modifier, glassesOfWater)
+        }
     }
 }

--- a/app/src/main/java/meehan/matthew/waterwidget/WaterActivityContent.kt
+++ b/app/src/main/java/meehan/matthew/waterwidget/WaterActivityContent.kt
@@ -1,0 +1,165 @@
+package meehan.matthew.waterwidget
+
+import android.content.Context
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import meehan.matthew.waterwidget.WaterWidget.Companion.RECOMMENDED_DAILY_GLASSES
+import meehan.matthew.waterwidget.WaterWidget.Companion.WATER_WIDGET_PREFS_KEY
+
+@Composable
+fun WaterActivityContent(
+    modifier: Modifier,
+    glassesOfWater: Int
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        val context = LocalContext.current
+        WaterActivityCounter(
+            context = context,
+            glassesOfWater = glassesOfWater,
+            modifier = Modifier
+                .fillMaxWidth()
+        )
+        WaterActivityGoal(
+            context = context,
+            glassesOfWater = glassesOfWater,
+            modifier = Modifier
+                .fillMaxWidth()
+        )
+        WaterActivityButtonLayout(
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}
+
+@Composable
+fun WaterActivityCounter(
+    context: Context,
+    glassesOfWater: Int,
+    modifier: Modifier
+) {
+    Text(
+        text = context.getString(
+            R.string.glasses_of_water_format,
+            glassesOfWater
+        ),
+        modifier = modifier,
+        style = TextStyle(
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            color = Color.White
+        ),
+    )
+}
+
+@Composable
+fun WaterActivityGoal(
+    context: Context,
+    glassesOfWater: Int,
+    modifier: Modifier
+) {
+    Text(
+        text =
+        when {
+            glassesOfWater >= RECOMMENDED_DAILY_GLASSES -> context.getString(
+                R.string.goal_met
+            )
+            else -> context.getString(
+                R.string.water_goal,
+                RECOMMENDED_DAILY_GLASSES
+            )
+        },
+        modifier = modifier,
+        style = TextStyle(
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            color = Color.White
+        ),
+    )
+}
+
+@Composable
+fun WaterActivityButtonLayout(
+    modifier: Modifier
+) {
+    val dataStore = LocalContext.current.dataStore
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            painter = painterResource(
+                id = R.drawable.ic_baseline_delete_outline_24
+            ),
+            contentDescription = null,
+            modifier = Modifier
+                .clickable(
+                    onClick = { clearWaterClickActionFun(dataStore) }
+                )
+
+        )
+        Image(
+            painter = painterResource(
+                id = R.drawable.ic_baseline_add_24
+            ),
+            contentDescription = null,
+            modifier = Modifier
+                .clickable(
+                    onClick = { addWaterClickActionFun(dataStore) }
+                )
+        )
+    }
+}
+
+fun clearWaterClickActionFun(dataStore: DataStore<Preferences>) {
+    GlobalScope.launch {
+        dataStore.updateData {
+            clearWater(it)
+        }
+    }
+}
+
+fun addWaterClickActionFun(dataStore: DataStore<Preferences>) {
+    GlobalScope.launch {
+        dataStore.updateData {
+            addWater(it)
+        }
+    }
+}
+
+internal const val FILENAME = "main"
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = FILENAME,
+)
+
+fun Context.glassesOfWater(): Flow<Int> = this.dataStore.data.map {
+    it[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] ?: 0
+}

--- a/app/src/main/java/meehan/matthew/waterwidget/WaterActivityContent.kt
+++ b/app/src/main/java/meehan/matthew/waterwidget/WaterActivityContent.kt
@@ -23,10 +23,8 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import meehan.matthew.waterwidget.WaterWidget.Companion.RECOMMENDED_DAILY_GLASSES
 import meehan.matthew.waterwidget.WaterWidget.Companion.WATER_WIDGET_PREFS_KEY
 
@@ -122,7 +120,7 @@ fun WaterActivityButtonLayout(
             contentDescription = null,
             modifier = Modifier
                 .clickable(
-                    onClick = { clearWaterClickActionFun(dataStore) }
+                    onClick = { clearWaterClickActionFunAsync(dataStore) }
                 )
 
         )
@@ -133,27 +131,12 @@ fun WaterActivityButtonLayout(
             contentDescription = null,
             modifier = Modifier
                 .clickable(
-                    onClick = { addWaterClickActionFun(dataStore) }
+                    onClick = { addWaterClickActionFunAsync(dataStore) }
                 )
         )
     }
 }
 
-fun clearWaterClickActionFun(dataStore: DataStore<Preferences>) {
-    GlobalScope.launch {
-        dataStore.updateData {
-            clearWater(it)
-        }
-    }
-}
-
-fun addWaterClickActionFun(dataStore: DataStore<Preferences>) {
-    GlobalScope.launch {
-        dataStore.updateData {
-            addWater(it)
-        }
-    }
-}
 
 internal const val FILENAME = "main"
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(

--- a/app/src/main/java/meehan/matthew/waterwidget/WaterActivityContent.kt
+++ b/app/src/main/java/meehan/matthew/waterwidget/WaterActivityContent.kt
@@ -108,7 +108,7 @@ fun WaterActivityGoal(
 fun WaterActivityButtonLayout(
     modifier: Modifier
 ) {
-    val dataStore = LocalContext.current.dataStore
+    val context = LocalContext.current
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -120,7 +120,7 @@ fun WaterActivityButtonLayout(
             contentDescription = null,
             modifier = Modifier
                 .clickable(
-                    onClick = { clearWaterClickActionFunAsync(dataStore) }
+                    onClick = { clearWaterClickActionFunAsync(context) }
                 )
 
         )
@@ -131,7 +131,7 @@ fun WaterActivityButtonLayout(
             contentDescription = null,
             modifier = Modifier
                 .clickable(
-                    onClick = { addWaterClickActionFunAsync(dataStore) }
+                    onClick = { addWaterClickActionFunAsync(context) }
                 )
         )
     }

--- a/app/src/main/java/meehan/matthew/waterwidget/WaterWidgetActions.kt
+++ b/app/src/main/java/meehan/matthew/waterwidget/WaterWidgetActions.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
+import androidx.glance.appwidget.updateAll
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import meehan.matthew.waterwidget.WaterWidget.Companion.MAX_GLASSES
@@ -14,21 +15,23 @@ import meehan.matthew.waterwidget.WaterWidget.Companion.WATER_WIDGET_PREFS_KEY
 
 class AddWaterClickAction : ActionCallback {
     override suspend fun onRun(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
-        addWaterClickActionFun(context.dataStore)
-        WaterWidget().update(context, glanceId)
+        addWaterClickActionFun(context)
+        WaterWidget().updateAll(context)
     }
 }
 
-fun addWaterClickActionFunAsync(dataStore: DataStore<Preferences>) {
+fun addWaterClickActionFunAsync(context: Context) {
     GlobalScope.launch {
-        addWaterClickActionFun(dataStore)
+        addWaterClickActionFun(context)
+
     }
 }
 
-private suspend fun addWaterClickActionFun(dataStore: DataStore<Preferences>) {
-    dataStore.updateData {
+private suspend fun addWaterClickActionFun(context: Context) {
+    context.dataStore.updateData {
         addWater(it)
     }
+    WaterWidget().updateAll(context)
 }
 
 private fun addWater(it: Preferences): Preferences =
@@ -42,23 +45,24 @@ private fun addWater(it: Preferences): Preferences =
 
 class ClearWaterClickAction : ActionCallback {
     override suspend fun onRun(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
-        clearWaterClickActionFun(context.dataStore)
-        WaterWidget().update(context, glanceId)
+        clearWaterClickActionFun(context)
+        WaterWidget().updateAll(context)
     }
 
 }
 
 
-fun clearWaterClickActionFunAsync(dataStore: DataStore<Preferences>) {
+fun clearWaterClickActionFunAsync(context: Context) {
     GlobalScope.launch {
-        clearWaterClickActionFun(dataStore)
+        clearWaterClickActionFun(context)
     }
 }
 
-private suspend fun clearWaterClickActionFun(dataStore: DataStore<Preferences>) {
-    dataStore.updateData {
+private suspend fun clearWaterClickActionFun(context: Context) {
+    context.dataStore.updateData {
         clearWater(it)
     }
+    WaterWidget().updateAll(context)
 }
 
 private fun clearWater(it: Preferences): Preferences =

--- a/app/src/main/java/meehan/matthew/waterwidget/WaterWidgetActions.kt
+++ b/app/src/main/java/meehan/matthew/waterwidget/WaterWidgetActions.kt
@@ -1,27 +1,37 @@
 package meehan.matthew.waterwidget
 
 import android.content.Context
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
 import androidx.glance.appwidget.action.ActionCallback
-import androidx.glance.appwidget.state.updateAppWidgetState
-import androidx.glance.state.PreferencesGlanceStateDefinition
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import meehan.matthew.waterwidget.WaterWidget.Companion.MAX_GLASSES
 import meehan.matthew.waterwidget.WaterWidget.Companion.WATER_WIDGET_PREFS_KEY
 
 class AddWaterClickAction : ActionCallback {
     override suspend fun onRun(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
-        updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) {
-            addWater(it)
-        }
+        addWaterClickActionFun(context.dataStore)
         WaterWidget().update(context, glanceId)
     }
 }
 
+fun addWaterClickActionFunAsync(dataStore: DataStore<Preferences>) {
+    GlobalScope.launch {
+        addWaterClickActionFun(dataStore)
+    }
+}
 
-fun addWater(it: Preferences): Preferences =
+private suspend fun addWaterClickActionFun(dataStore: DataStore<Preferences>) {
+    dataStore.updateData {
+        addWater(it)
+    }
+}
+
+private fun addWater(it: Preferences): Preferences =
     it.toMutablePreferences()
         .apply {
             val glassesOfWater = this[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] ?: 0
@@ -32,16 +42,26 @@ fun addWater(it: Preferences): Preferences =
 
 class ClearWaterClickAction : ActionCallback {
     override suspend fun onRun(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
-        updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) {
-            clearWater(it)
-        }
+        clearWaterClickActionFun(context.dataStore)
         WaterWidget().update(context, glanceId)
     }
 
 }
 
 
-fun clearWater(it: Preferences): Preferences =
+fun clearWaterClickActionFunAsync(dataStore: DataStore<Preferences>) {
+    GlobalScope.launch {
+        clearWaterClickActionFun(dataStore)
+    }
+}
+
+private suspend fun clearWaterClickActionFun(dataStore: DataStore<Preferences>) {
+    dataStore.updateData {
+        clearWater(it)
+    }
+}
+
+private fun clearWater(it: Preferences): Preferences =
     it.toMutablePreferences()
         .apply {
             this[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] = 0

--- a/app/src/main/java/meehan/matthew/waterwidget/WaterWidgetActions.kt
+++ b/app/src/main/java/meehan/matthew/waterwidget/WaterWidgetActions.kt
@@ -1,6 +1,7 @@
 package meehan.matthew.waterwidget
 
 import android.content.Context
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.glance.GlanceId
 import androidx.glance.action.ActionParameters
@@ -13,26 +14,35 @@ import meehan.matthew.waterwidget.WaterWidget.Companion.WATER_WIDGET_PREFS_KEY
 class AddWaterClickAction : ActionCallback {
     override suspend fun onRun(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
         updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) {
-            it.toMutablePreferences()
-                .apply {
-                    val glassesOfWater = this[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] ?: 0
-                    if (glassesOfWater < MAX_GLASSES) {
-                        this[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] = glassesOfWater + 1
-                    }
-                }
+            addWater(it)
         }
         WaterWidget().update(context, glanceId)
     }
 }
 
+
+fun addWater(it: Preferences): Preferences =
+    it.toMutablePreferences()
+        .apply {
+            val glassesOfWater = this[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] ?: 0
+            if (glassesOfWater < MAX_GLASSES) {
+                this[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] = glassesOfWater + 1
+            }
+        }
+
 class ClearWaterClickAction : ActionCallback {
     override suspend fun onRun(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
         updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) {
-            it.toMutablePreferences()
-                .apply {
-                    this[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] = 0
-                }
+            clearWater(it)
         }
         WaterWidget().update(context, glanceId)
     }
+
 }
+
+
+fun clearWater(it: Preferences): Preferences =
+    it.toMutablePreferences()
+        .apply {
+            this[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] = 0
+        }

--- a/app/src/main/java/meehan/matthew/waterwidget/WaterWidgetContent.kt
+++ b/app/src/main/java/meehan/matthew/waterwidget/WaterWidgetContent.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
-import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.glance.GlanceModifier
 import androidx.glance.Image
@@ -12,19 +11,19 @@ import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.action.actionRunCallback
-import androidx.glance.currentState
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
+import androidx.glance.layout.Row
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
-import androidx.glance.layout.Row
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextAlign
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import meehan.matthew.waterwidget.WaterWidget.Companion.RECOMMENDED_DAILY_GLASSES
-import meehan.matthew.waterwidget.WaterWidget.Companion.WATER_WIDGET_PREFS_KEY
 
 @Composable
 fun WaterWidgetContent(
@@ -35,8 +34,10 @@ fun WaterWidgetContent(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         val context = LocalContext.current
-        val prefs = currentState<Preferences>()
-        val glassesOfWater = prefs[intPreferencesKey(WATER_WIDGET_PREFS_KEY)] ?: 0
+        val glassesOfWater = runBlocking {
+            context.dataStore.data.first()
+                .get(intPreferencesKey(WaterWidget.WATER_WIDGET_PREFS_KEY)) ?: 0
+        }
         WaterWidgetCounter(
             context = context,
             glassesOfWater = glassesOfWater,

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.0.4"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://androidx.dev/snapshots/latest/artifacts/repository' }
     }
 }
 rootProject.name = "WaterWidget"


### PR DESCRIPTION
Thanks for your article.
After reading it I was wondering if values saved into DataStore Preferences are available from the App itself.
The answer is no - each Widget uses its preferences file with its Id (like `29`) in the name (like `appWidget-29.preferences_pb`).

However, the code can be useful to show the difference between Glance's compose and Compose itself (as I've migrated `WaterWidgetContent.kt` into `WaterActivityContent.kt`).
